### PR TITLE
ensure range parameters are type int

### DIFF
--- a/pyseqslam/seqslam.py
+++ b/pyseqslam/seqslam.py
@@ -243,7 +243,7 @@ class SeqSLAM():
         # TODO parallelize
         matches = np.nan*np.ones((DD.shape[1],2))    
         # parfor?
-        for N in range(self.params.matching.ds/2, DD.shape[1]-self.params.matching.ds/2):
+        for N in range(int(self.params.matching.ds/2), int(DD.shape[1]-self.params.matching.ds/2)):
             # find a single match
             
             # We shall search for matches using velocities between

--- a/pyseqslam/seqslam.py
+++ b/pyseqslam/seqslam.py
@@ -186,8 +186,8 @@ class SeqSLAM():
     
         #parfor?
         for i in range(D.shape[0]):
-            a=np.max((0, i-self.params.contrastEnhancement.R/2))
-            b=np.min((D.shape[0], i+self.params.contrastEnhancement.R/2+1))                                                        
+            a=int(np.max((0, i-self.params.contrastEnhancement.R/2)))
+            b=int(np.min((D.shape[0], i+self.params.contrastEnhancement.R/2+1)))
             v = D[a:b, :]
             DD[i,:] = (D[i,:] - np.mean(v, 0)) / np.std(v, 0, ddof=1)  
         


### PR DESCRIPTION
Fixes failure in getMatches loop iteration in the presence of type np.float64 and a similar problem with float range parameters when performing contrast enhancement